### PR TITLE
Add export

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,3 +66,5 @@ declare class SimpleReactValidator {
   message(field: string, inputValue: any, validations: any, options: IObject): any;
   helpers: IHelpers;
 }
+
+export default SimpleReactValidator;


### PR DESCRIPTION
Fixes "index.d.ts is not a module" when importing using Typescript.