### PR TITLE
Fix typescript error

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,10 +49,10 @@ declare class SimpleReactValidator {
   messagesShown: boolean;
   rules: IRules;
 
-  messages: IOptions.messages;
-  className: IOptions.className;
-  autoForceUpdate: IOptions.autoForceUpdate;
-  element: IOptions.element;
+  messages: IOptions["messages"];
+  className: IOptions["className"];
+  autoForceUpdate: IOptions["autoForceUpdate"];
+  element: IOptions["element"];
 
   getErrorMessages(): IObject;
   showMessages(): void;


### PR DESCRIPTION
Fixes typescript compliation errors:
"Cannot access 'IOptions.messages' because 'IO…ptions' is a type, but not a namespace. Did you mean to retrieve the type of the property 'messages' in 'IOptions' with 'IOptions[\"messages\"]'?",