### PR TITLE
Update the  definition for `validators` option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,8 @@ interface IRules {
   [key: IRule | string]: {
     message: string;
     rule: (val: any, params?: any) => boolean;
+    messageReplace?: (message: string, params?: any) => string;
+    required?: boolean;
   }
 }
 


### PR DESCRIPTION
Add type definition for `messageReplace` and `required` in the definition for `validators` option (`IRules`).

Fixes: #436 